### PR TITLE
Specify topic-creation and replication-factor

### DIFF
--- a/root/opt/kafka/bin/server.properties.sh
+++ b/root/opt/kafka/bin/server.properties.sh
@@ -33,6 +33,8 @@ log.dirs=${KAFKA_LOG_DIRS}
 num.partitions=${KAFKA_NUM_PARTITIONS}
 num.recovery.threads.per.data.dir=1
 delete.topic.enable=${KAFKA_DELETE_TOPICS}
+auto.create.topics.enable=${KAFKA_AUTO_CREATE_TOPICS}
+default.replication.factor=${KAFKA_REPLICATION_FACTOR}
 ############################# Log Flush Policy #############################
 #log.flush.interval.messages=10000
 #log.flush.interval.ms=1000


### PR DESCRIPTION
Added the ability to use `$KAFKA_AUTO_CREATE_TOPICS` and `$KAFKA_REPLICATION_FACTOR` to control automatic topic creation and the default replication factor on the broker.